### PR TITLE
For replit safety run token thru .env

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+Token: Pastetokenhere

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The default Bot cmd for nuking is `.nuke` no cap!
 - Delete the `main.py`
 - Copy the extracted items to replit (drag 'em!)
 - Add Discord & Colorama Python Packages if they're missing.
+- Use secret keys instead of .env to run
 
 ### Local
 - Make sure you have installed Python

--- a/README.md
+++ b/README.md
@@ -56,15 +56,15 @@ The default Bot cmd for nuking is `.nuke` no cap!
 # How To Customize
 ### Replit
 - Open the repl
-- go to `main.py`
-- there is, in `token = ""` enter your token. it should be like (`"token"`) in the "".
+- create a secret key
+- Put name `Token` and value your token.
 - Safely edit the channel names if you want.
 - Edit the command if you want. By default, its `.nuke` no cap!
 
 ### Local
-- Right click the `main.py`
 - Open in your code editor
-- there is, in `token = ""` enter your token. it should be like (`"token"`) in the "".
+- Create a file called `.env`
+- Put there: `Token: Pastetokenhere`
 - Safely edit the channel names if you want.
 - Edit the command if you want. By default, its `.nuke` no cap!
 
@@ -72,4 +72,4 @@ The default Bot cmd for nuking is `.nuke` no cap!
 - Make sure your bot have both `server members intent` & `presence intent` on
 - Before start nuking, make sure your bot have administrator permissions.
 - DO NOT mention that you do server raidings. Someone might report you for this.
-- Don't Share the Bot token with anyone. If it got leaked then regenerate it and update the `main.py`.
+- Don't Share the Bot token with anyone. If it got leaked then regenerate it and update the `.env`.

--- a/main.py
+++ b/main.py
@@ -5,9 +5,7 @@ from discord import Permissions
 from colorama import Fore, Style
 import asyncio
 
-# Check readme.md for lastest updates
-
-token = "PasteHere"
+# Check readme.md for latest updates
 
 # If you are having issues, watch this video: https://streamable.com/7eovst or follow message listed below
 
@@ -115,4 +113,5 @@ async def on_guild_channel_create(channel):
         await channel.send(random.choice(SPAM_MESSAGE))
 
 
-client.run(token, bot=True)
+my_secret = os.environ['Token']
+client.run(my_secret)


### PR DESCRIPTION
If tokens were put in main.py everyone could get the token by opening repl's code, no one expect the owner would be able to see their bot's token if they putted it thru secret keys. For local, .env is always good to use.